### PR TITLE
[Feature] 카카오맵 API 연동 및 현재 위치 기반 맵 이동 기능 추가

### DIFF
--- a/apps/client/src/app/(map)/map-page/layout.tsx
+++ b/apps/client/src/app/(map)/map-page/layout.tsx
@@ -1,3 +1,4 @@
+import HomeMainHeader from '@/components/layouts/HomeMainHeader';
 import GnbNavBar from '@/components/layouts/GnbNavBar';
 
 export default function layout({
@@ -7,6 +8,7 @@ export default function layout({
 }>) {
   return (
     <div className="min-h-screen bg-white">
+      <HomeMainHeader />
       {children}
       <GnbNavBar />
     </div>

--- a/apps/client/src/app/(map)/map-page/page.tsx
+++ b/apps/client/src/app/(map)/map-page/page.tsx
@@ -1,0 +1,6 @@
+import MainMap from '@/components/pages/map/MainMap';
+import React from 'react';
+
+export default function page() {
+  return <MainMap />;
+}

--- a/apps/client/src/components/layouts/GnbNavBar.tsx
+++ b/apps/client/src/components/layouts/GnbNavBar.tsx
@@ -13,7 +13,12 @@ export default function GnbNavBar() {
         <ul className="relative flex items-center justify-evenly px-2 h-full">
           <GnbMenu id="/" link="./" icon={Home} />
           <GnbMenu id="/myReservation" link="./myReservation" icon={Bookmark} />
-          <GnbMenu id="/map" link="./" icon={ParkingMarkerIcon} main />
+          <GnbMenu
+            id="/map-page"
+            link="./map-page"
+            icon={ParkingMarkerIcon}
+            main
+          />
           <GnbMenu id="/chat" link="./" icon={MessageSquareText} />
           <GnbMenu id="/my-page" link="./my-page" icon={User} />
         </ul>

--- a/apps/client/src/components/pages/map/MainMap.tsx
+++ b/apps/client/src/components/pages/map/MainMap.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useParkingFilterStore } from '@/store/useParkingFilterStore';
+import { getCurrentLocationUtils } from '@/utils/getCurrentLocationUtils';
+import React, { useEffect } from 'react';
+import { Map, useKakaoLoader } from 'react-kakao-maps-sdk';
+
+export default function MainMap() {
+  const [loading, error] = useKakaoLoader({
+    appkey: process.env.NEXT_PUBLIC_KAKAO_JS_KEY || '',
+    libraries: ['services', 'clusterer'],
+  });
+
+  const parkingFilter = useParkingFilterStore((state) => state);
+
+  const currentLocation = async () => {
+    try {
+      const { latitude, longitude } = await getCurrentLocationUtils();
+      parkingFilter.setMapCenter(latitude, longitude, null);
+
+      console.log('현재위치', latitude, longitude);
+    } catch (error) {
+      console.log('현재위치 실패', error);
+    }
+  };
+
+  useEffect(() => {
+    currentLocation();
+  }, []);
+
+  if (loading) return <div>지도 불러오는 중...</div>;
+  if (error) return <div>카카오맵 로딩 실패: {error.message}</div>;
+
+  return (
+    <>
+      <Map
+        center={{
+          lat: parkingFilter.mapCenter?.lat || 37.5727,
+          lng: parkingFilter.mapCenter?.lng || 126.9695,
+        }}
+        level={5}
+        className="w-full min-h-screen z-0"
+        isPanto
+      />
+    </>
+  );
+}

--- a/apps/client/src/components/pages/reservation/FilterInfoSection.tsx
+++ b/apps/client/src/components/pages/reservation/FilterInfoSection.tsx
@@ -9,7 +9,7 @@ import VehicleInfoBox from './VehicleInfoBox';
 import LocationFilter from './LocationFilter';
 
 export default function FilterInfoSection() {
-  const [select, setSelect] = useState<'schedule' | 'location' | 'evcharge'>(
+  const [select, setSelect] = useState<'schedule' | 'mapCenter' | 'evcharge'>(
     'schedule'
   );
 
@@ -26,11 +26,11 @@ export default function FilterInfoSection() {
           <ScheduleInfoBox />
         </FilterInfoBox>
         <FilterInfoBox
-          id="location"
+          id="mapCenter"
           boxName="위치"
           buttonName="위치 추가"
-          selected={select === 'location'}
-          onClick={() => setSelect('location')}
+          selected={select === 'mapCenter'}
+          onClick={() => setSelect('mapCenter')}
         >
           <LocationFilter />
         </FilterInfoBox>

--- a/apps/client/src/components/pages/reservation/LocationFilter.tsx
+++ b/apps/client/src/components/pages/reservation/LocationFilter.tsx
@@ -19,15 +19,15 @@ export default function LocationFilter() {
     searchLocationResultType[]
   >([]);
 
-  const loacation = useParkingFilterStore((state) => state.location);
-  const setLocation = useParkingFilterStore((state) => state.setLocation);
+  const loacation = useParkingFilterStore((state) => state.mapCenter);
+  const setMapCenter = useParkingFilterStore((state) => state.setMapCenter);
 
   useEffect(() => {
     if (loading) return;
 
     if (inputValue === '') {
       setSearchResults([]);
-      setLocation(null, null, null);
+      setMapCenter(37.5727, 126.9695, null);
       return;
     }
 

--- a/apps/client/src/components/pages/reservation/SearchLocationResults.tsx
+++ b/apps/client/src/components/pages/reservation/SearchLocationResults.tsx
@@ -7,7 +7,7 @@ export default function SearchResultsList({
   setSearchResults,
   setInputValue,
 }: SearchResultsListProps) {
-  const setLocation = useParkingFilterStore((state) => state.setLocation);
+  const setMapCenter = useParkingFilterStore((state) => state.setMapCenter);
 
   return (
     <div className="w-full h-100 overflow-y-scroll ">
@@ -20,7 +20,7 @@ export default function SearchResultsList({
             onMouseDown={() => {
               setSearchResults([]);
               setInputValue(data.content);
-              setLocation(data.position.lat, data.position.lng, data.content);
+              setMapCenter(data.position.lat, data.position.lng, data.content);
             }}
           >
             <p className="font-medium leading-tight mt-2">{data.content}</p>

--- a/apps/client/src/store/useParkingFilterStore.tsx
+++ b/apps/client/src/store/useParkingFilterStore.tsx
@@ -5,18 +5,27 @@ interface ParkingFilterStoreType {
     entryTime: string | null;
     exitTime?: string | null;
   };
-  location?: {
-    lat: number | null;
-    lng: number | null;
+  mapCenter?: {
+    lat: number;
+    lng: number;
     locationName: string | null;
+  };
+  mapBounds?: {
+    maxlat: number | null;
+    minlat: number | null;
+    maxlng: number | null;
+    minlng: number | null;
   };
   evcharge?: number;
   setSchedule: (entryTime: string | null, exitTime?: string | null) => void;
-  setLocation: (
-    lat: number | null,
-    lng: number | null,
-    loactionName: string | null
+  setMapCenter: (lat: number, lng: number, loactionName: string | null) => void;
+  setMapBounds: (
+    maxlat: number | null,
+    minlat: number | null,
+    maxlng: number | null,
+    minlng: number | null
   ) => void;
+
   setVehicle: (evcharge: number) => void;
 }
 
@@ -27,10 +36,12 @@ export const useParkingFilterStore = create<ParkingFilterStoreType>((set) => ({
     exitTime: '',
   },
   location: {
-    lat: null,
-    lng: null,
+    lat: 37.5727,
+    lng: 126.9695,
     locationName: '',
   },
+  mapBounds: { maxlat: null, minlat: null, maxlng: null, minlng: null },
+
   evcharge: 0,
 
   setSchedule: (entryTime, exitTime) => {
@@ -42,12 +53,23 @@ export const useParkingFilterStore = create<ParkingFilterStoreType>((set) => ({
     }));
   },
 
-  setLocation: (lat, lng, locationName) => {
+  setMapCenter: (lat, lng, locationName) => {
     set(() => ({
-      location: {
+      mapCenter: {
         lat,
         lng,
         locationName,
+      },
+    }));
+  },
+
+  setMapBounds: (maxlat, minlat, maxlng, minlng) => {
+    set(() => ({
+      mapBounds: {
+        maxlat,
+        minlat,
+        maxlng,
+        minlng,
       },
     }));
   },

--- a/apps/client/src/types/filterInfoType.ts
+++ b/apps/client/src/types/filterInfoType.ts
@@ -28,7 +28,7 @@ export interface FilterInfoType {
     entryTime: string;
     exitTime?: string;
   };
-  location?: {
+  mapCenter?: {
     lat: number;
     lng: number;
     locationName?: string;

--- a/apps/client/src/utils/getCurrentLocationUtils.ts
+++ b/apps/client/src/utils/getCurrentLocationUtils.ts
@@ -1,0 +1,20 @@
+export const getCurrentLocationUtils = (): Promise<{
+  latitude: number;
+  longitude: number;
+}> => {
+  return new Promise((resolve, reject) => {
+    if (!navigator.geolocation) {
+      reject(new Error('Geolocation을 지원하지 않습니다.'));
+    }
+
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        const { latitude, longitude } = position.coords;
+        resolve({ latitude, longitude });
+      },
+      (error) => {
+        reject(error);
+      }
+    );
+  });
+};


### PR DESCRIPTION
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Isuue Number) -->

## 💡 PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 파일 혹은 폴더명 수정 및 삭제
- [ ] 기타 사소한 변경

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 변경 사항에 대한 테스트를 지켰는가
- [x] 커밋 메시지가 팀 컨벤션을 지켰는가
- [x] 브랜치 명이 규칙에 맞는가
- [x] 기능 정상 동작 확인 완료

##  📝 작업 내용
<!-- 작업한 내용을 작성해주세요 -->
- 카카오맵 API 연동 : map-page 
- 하단 네비게이션바 지도 버튼 map-page와 연동
- 현재 위치 기반 맵 이동 기능
  - 현재 위치 설정 utils 추가
  - 맵 페이지 이동 시 현재 위치 사용 허용 여부 설정 
    -> 허용O : 현재 위치를 중심으로 맵 영역 설정 <-> 허용X: 서울 광화문을 중심으로 설정함(임시).
  - 맵 영역도 상태관리하기 위해 useParkingFilterStore에 mapCenter, mapBounds 설정
     (mapBounds: 현재 화면 기준 위경도 최대최솟값 / mapCenter: 지도 중심 위경도) 
